### PR TITLE
Added support for the `restartFrame` DAP request

### DIFF
--- a/prolog/server.pl
+++ b/prolog/server.pl
@@ -213,6 +213,12 @@ da_server_command("disconnect", RequestSeq, _Message, Out, _W, State, State, Seq
     maplist(da_server_disconnect_debugee, State),
     dap_response(Out, Seq0, RequestSeq, "disconnect"),
     succ(Seq0, Seq).
+da_server_command("restartFrame", RequestSeq, Message, Out, _W, State, State, Seq0, Seq) :-
+    _{ arguments : Args    } :< Message,
+    _{ frameId   : FrameId } :< Args,
+    dap_response(Out, Seq0, RequestSeq, "restartFrame"),
+    succ(Seq0, Seq),
+    maplist([debugee(PrologThreadId, _, _)]>>thread_send_message(PrologThreadId, restart_frame(FrameId)), State).
 da_server_command(Command, RequestSeq, _Message, Out, _W, State, State, Seq0, Seq) :-
     format(string(ErrorMessage), "Command \"~w\" is not implemented", [Command]),
     dap_error(Out, Seq0, RequestSeq, Command, ErrorMessage),

--- a/prolog/tracer.pl
+++ b/prolog/tracer.pl
@@ -112,6 +112,7 @@ da_tracer_handled_message(stack_trace(RequestId), Port, Frame, _Choice, loop, S,
 da_tracer_handled_message(step_in, _Port, _Frame, _Choice, continue, _S, _W) :- !.
 da_tracer_handled_message(disconnect, _Port, _Frame, _Choice, nodebug, _S, _W) :- !.
 da_tracer_handled_message(continue, _Port, _Frame, _Choice, nodebug, _S, _W) :- !.
+da_tracer_handled_message(restart_frame(FrameId), _Port, _Frame, _Choice, retry(FrameId), _S, _W) :- !.
 
 :- det(da_stack_frames/4).
 da_stack_frames(Depth, F, Port, Frames) :-


### PR DESCRIPTION
As [requested](https://swi-prolog.discourse.group/t/debug-adapter-protocol-dap/4473/15) by Jan W., this PR adds support for the `restartFrame` DAP request, which resembles SWI-Prolog's `retry` debugger actions