### PR TITLE
FIX: report DAP conforming `stopped` event `reason` fields

### DIFF
--- a/prolog/TODO
+++ b/prolog/TODO
@@ -8,3 +8,8 @@
 * TODO Utilize the DAP Json Schema
   DAP is defined by machine-reabable Json Schema draft 4, we should utilize it to eliminate manual
   implementation of many procotol details.
+* TODO Use `predicate_options/1` for documentation and safety where warranted
+* TODO Consider using [[https://www.swi-prolog.org/pldoc/doc_for?object=message_hook/3][`message_link/3`]] to implement the DAP `output` event
+* TODO Consider the security of the debugger
+** TODO Log every user requested executed goal
+** TODO Consider verifying the safety of requested goals with [[https://www.swi-prolog.org/pldoc/doc_for?object=sandbox%3Asafe_goal/1][safe_goal/1]]

--- a/prolog/debug_adapter/clause.pl
+++ b/prolog/debug_adapter/clause.pl
@@ -120,7 +120,7 @@ da_clause_source_term(_ClauseRef, Module, DecompiledClause, VariablesOffset, Sou
 
 %!  da_clause_decompiled(+ClauseRef, +Module, +DecompiledClause) is det.
 
-:- det(da_clause_decompiled/3).
+:- det(da_clause_decompiled/4).
 da_clause_decompiled(ClauseRef, Module, DecompiledClause, VariablesOffset) :-
     '$clause'(Head0, Body, ClauseRef, VariablesOffset),
     qualified(Head0, Module, Head),

--- a/prolog/debug_adapter/server.pl
+++ b/prolog/debug_adapter/server.pl
@@ -202,20 +202,29 @@ prolog_dap_source_span(reference(SourceReference),
                        0, 0, null, null
                       ).
 
-prolog_dap_stack_frame(stack_frame(Id, PI, _Alternative, SourceSpan),
-                       _{ id          : Id,
-                          name        : Name,
-                          line        : SL,
-                          column      : SC,
-                          endLine     : EL,
-                          endColumn   : EC,
-                          source      : DAPSource
-%                         alternative : DAPAlternative  experiment with a custom protocol extension
+prolog_dap_stack_frame(stack_frame(Id, InFrameLabel, PI, _Alternative, SourceSpan),
+                       _{ id                          : Id,
+                          name                        : Name,
+                          line                        : SL,
+                          column                      : SC,
+                          endLine                     : EL,
+                          endColumn                   : EC,
+                          source                      : DAPSource,
+%                         alternative                 : DAPAlternative % for experiment with a custom protocol extension
+                          instructionPointerReference : DAPLabel
                         }
                       ) :-
 %   prolog_dap_alternative(Alternative, DAPAlternative),
     term_string(PI, Name),
-    prolog_dap_source_span(SourceSpan, DAPSource, SL, SC, EL, EC).
+    prolog_dap_source_span(SourceSpan, DAPSource, SL, SC, EL, EC),
+    prolog_dap_in_frame_label(InFrameLabel, DAPLabel).
+
+prolog_dap_in_frame_label(port(Port), DAPLabel) :-
+    !,
+    functor(Port, PortName, _Arity),
+    atom_string(PortName, DAPLabel).
+prolog_dap_in_frame_label(pc(PC), DAPLabel) :-
+    number_string(PC, DAPLabel).
 
 
 da_server_handled_message("request", RequestSeq, Message0, Out, W, State0, State, Seq0, Seq) :-

--- a/prolog/debug_adapter/stack.pl
+++ b/prolog/debug_adapter/stack.pl
@@ -37,19 +37,19 @@ da_stack_trace(FrameId, StackTrace) :-
     da_frame_pc_stack(ParentFrameId, PC, da_stack_frame_info, StackTrace).
 
 da_stack_frame_info(FrameId, PC,
-                    stack_frame(FrameId, PredicateIndicator, label(frame, AlternativeFrameId), SourceSpan)) :-
+                    stack_frame(FrameId, pc(PC), PredicateIndicator, label(frame, AlternativeFrameId), SourceSpan)) :-
     da_frame_predicate_indicator(FrameId, PredicateIndicator),
     da_frame_alternative_frame(FrameId, AlternativeFrameId),
     da_frame_pc_source_span(FrameId, PC, SourceSpan).
 
 da_stack_frame_at_port(FrameId, unify, ChoicePoint,
-                       stack_frame(FrameId, PredicateIndicator, Alternative, SourceSpan)) :-
+                       stack_frame(FrameId, port(unify), PredicateIndicator, Alternative, SourceSpan)) :-
     !,
     da_frame_predicate_indicator(FrameId, PredicateIndicator),
     da_frame_alternative(FrameId, ChoicePoint, Alternative),
     da_frame_clause_source_span(FrameId, SourceSpan).
 da_stack_frame_at_port(FrameId, Port, ChoicePoint,
-                       stack_frame(FrameId, PredicateIndicator, Alternative, SourceSpan)) :-
+                       stack_frame(FrameId, port(Port), PredicateIndicator, Alternative, SourceSpan)) :-
     da_frame_predicate_indicator(FrameId, PredicateIndicator),
     da_frame_alternative(FrameId, ChoicePoint, Alternative),
     da_frame_port_source_span(FrameId, Port, SourceSpan).


### PR DESCRIPTION
Beforehand the current Prolog port was reported in place of the
stopped reason. We now calculate the correct stopped reason as
prescribed by the DAP specs, and use the `instructionPointerReference`
field of reported stack frames to denote the port/pc in which the
frame is paused.

