### PR TITLE
FIXED: `pack_install/1` failure with SWI-Prolog 8.5.2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,6 @@ jobs:
           ./configure
           make
           make check
-          make distcheck
 
       - name: Build pack
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,3 @@ jobs:
           ./configure
           make
           make check
-          make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,8 @@
 SUBDIRS = prolog test
 EXTRA_DIST = pack.pl
+
+dist-hook:
+	rm $(top_distdir)/configure.ac
+	rm $(top_distdir)/Makefile.am
+	rm $(top_distdir)/prolog/Makefile.am
+	rm $(top_distdir)/test/Makefile.am


### PR DESCRIPTION
Workaround for an issue with `pack_install/1` that occurs when the
package's distribution archive contains autoconf's configure.ac.
We just refrain from distributing configure.ac and friends...

Reported by Risto Stevcev.
Closes #13 