### PR TITLE
FIX: Debugging non-module source files

### DIFF
--- a/prolog/debug_adapter/clause.pl
+++ b/prolog/debug_adapter/clause.pl
@@ -101,7 +101,7 @@ da_clause_source_term(ClauseRef, Module, DecompiledClause, VariablesOffset, Sour
                                                     ]),
                        close(Stream)),
     prolog_clause:unify_clause(SourceClause, DecompiledClause, Module, SourceLayout0, SourceLayout),
-    prolog_clause:make_varnames(SourceClause, DecompiledClause, VariablesOffset, VarNames0, VarNames).
+    prolog_clause:make_varnames(SourceClause, DecompiledClause, VariablesOffset, VarNames0, VarNames), !.
 da_clause_source_term(_ClauseRef, Module, DecompiledClause, VariablesOffset, SourceClause, null, SourceLayout, VarNames) :-
     setup_call_cleanup(new_memory_file(MemFile),
                        ( setup_call_cleanup(open_memory_file(MemFile, write, MemOut),
@@ -116,7 +116,7 @@ da_clause_source_term(_ClauseRef, Module, DecompiledClause, VariablesOffset, Sou
                                            close(MemIn))),
                        free_memory_file(MemFile)),
     prolog_clause:unify_clause(SourceClause, DecompiledClause, Module, SourceLayout0, SourceLayout),
-    prolog_clause:make_varnames(SourceClause, DecompiledClause, VariablesOffset, VarNames0, VarNames).
+    prolog_clause:make_varnames(SourceClause, DecompiledClause, VariablesOffset, VarNames0, VarNames), !.
 
 %!  da_clause_decompiled(+ClauseRef, +Module, +DecompiledClause) is det.
 

--- a/prolog/debug_adapter/server.pl
+++ b/prolog/debug_adapter/server.pl
@@ -74,7 +74,9 @@ da_server_handled_stream(In, _R, In, Out, W, State0, State, Seq0, Seq) :-
     dap_read(In, Message0),
     del_dict(seq,  Message0, ClientSeq, Message1),
     del_dict(type, Message1, Type, Message),
-    da_server_handled_message(Type, ClientSeq, Message, Out, W, State0, State, Seq0, Seq).
+    debug(dap(server), "Received message ~w from stdin", [Message]),
+    da_server_handled_message(Type, ClientSeq, Message, Out, W, State0, State, Seq0, Seq),
+    debug(dap(server), "Handled message ~w from stdin", [Message]).
 da_server_handled_stream(_In, R, R, Out, _, State0, State, Seq0, Seq) :-
     get_code(R, _),
     da_server_handled_debugee_messages(Out, State0, State, Seq0, Seq).
@@ -105,6 +107,7 @@ da_server_handled_debugee_messages(Out, State0, State, Seq0, Seq) :-
     ->  thread_get_message(DebugeeThreadId-Message),
         debug(dap(server), "Received message ~w from debugee thread ~w", [Message, DebugeeThreadId]),
         da_server_handled_debugee_message(DebugeeThreadId, Message, Out, State0, State1, Seq0, Seq1),
+        debug(dap(server), "Handled message ~w from debugee thread ~w", [Message, DebugeeThreadId]),
         da_server_handled_debugee_messages(Out, State1, State, Seq1, Seq)
     ;   State = State0,
         Seq   = Seq0

--- a/prolog/debug_adapter/tracer.pl
+++ b/prolog/debug_adapter/tracer.pl
@@ -39,10 +39,16 @@ prolog:open_source_hook(Path, Stream, _Options) :-
 da_debugee(ModulePath, Goal, ServerThreadId, ServerInterruptHandle) :-
     asserta(da_debugee_server(ServerThreadId, ServerInterruptHandle)),
     thread_get_message(_), % wait for a trigger from the server
+    debug(dap(tracer), "starting debugee thread with source file ~w and goal ~w", [ModulePath, Goal]),
     absolute_file_name(ModulePath, AbsModulePath, []),
-    use_module(AbsModulePath),
-    module_property(Module, file(AbsModulePath)),
-    qualified(QGoal, Module, Goal),
+    debug(dap(tracer), "Absolute path to source file ~w", [AbsModulePath]),
+    load_files(AbsModulePath),
+    debug(dap(tracer), "Loaded source file ~w", [AbsModulePath]),
+    (   module_property(Module, file(AbsModulePath))
+    ->  qualified(QGoal, Module, Goal)
+    ;   QGoal = Goal
+    ),
+    debug(dap(tracer), "debugee qualified goal ~w", [QGoal]),
     da_trace(QGoal, ServerThreadId, ServerInterruptHandle).
 
 da_debugee_emitted_message(Message, ServerThreadId, ServerInterruptHandle) :-


### PR DESCRIPTION
Use `load_files/1` instead of `use_module/1` to load the debugee's source file